### PR TITLE
Remove spectating constraint; fix referee unable to spectate after rejoining; split websocket frames on writing

### DIFF
--- a/multiplayer/game.go
+++ b/multiplayer/game.go
@@ -955,11 +955,6 @@ func (game *Game) initializeSpectator(user *sessions.User) bool {
 
 	user.StopSpectatingAll()
 
-	if len(game.playersInMatch) != 2 && !common.HasUserGroup(user.Info.UserGroups, common.UserGroupDeveloper) {
-		sessions.SendPacketToUser(packets.NewServerNotificationInfo("You can only spectate matches with two players."), user)
-		return false
-	}
-
 	for _, playerId := range game.playersInMatch {
 		if player := sessions.GetUserById(playerId); player != nil {
 			player.AddSpectator(user)

--- a/sessions/packets.go
+++ b/sessions/packets.go
@@ -2,6 +2,8 @@ package sessions
 
 import (
 	"encoding/json"
+	"fmt"
+	"github.com/gobwas/ws"
 	"github.com/gobwas/ws/wsutil"
 	"net"
 )
@@ -18,11 +20,21 @@ func SendPacketToConnection(data interface{}, conn net.Conn) {
 		return
 	}
 
-	err = wsutil.WriteServerText(conn, j)
+	writer := wsutil.GetWriter(conn, ws.StateServerSide, ws.OpBinary, wsutil.DefaultWriteBuffer)
+
+	_, err = writer.Write(j)
+
+	if err == nil {
+		err = writer.Flush()
+	}
+
+	wsutil.PutWriter(writer)
 
 	if err != nil {
+		fmt.Printf("error: %v\n", err)
 		return
 	}
+
 }
 
 // SendPacketToUser Sends a packet to a given user


### PR DESCRIPTION
1. Remove the constraint where spectators can only spectate 2-player matches
2. Referee should now be able to spectate normally after rejoining the lobby. This requires point 1 to get implemented
3. When sending websocket packets, split them into multiple frames if they are too big. Also, send them with OpCode Binary. Decoding work could be done on client side, and we can catch UTF8 encoding error that way. This is done because there is an error that I suspect is related to UTF8 decoding. I want to check if it's true.