### PR TITLE
Revert "Use wsutil.GetWriter to split large packets into multiple frames"

### DIFF
--- a/sessions/packets.go
+++ b/sessions/packets.go
@@ -2,8 +2,6 @@ package sessions
 
 import (
 	"encoding/json"
-	"fmt"
-	"github.com/gobwas/ws"
 	"github.com/gobwas/ws/wsutil"
 	"net"
 )
@@ -20,21 +18,11 @@ func SendPacketToConnection(data interface{}, conn net.Conn) {
 		return
 	}
 
-	writer := wsutil.GetWriter(conn, ws.StateServerSide, ws.OpBinary, wsutil.DefaultWriteBuffer)
-
-	_, err = writer.Write(j)
-
-	if err == nil {
-		err = writer.Flush()
-	}
-
-	wsutil.PutWriter(writer)
+	err = wsutil.WriteServerText(conn, j)
 
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
 		return
 	}
-
 }
 
 // SendPacketToUser Sends a packet to a given user


### PR DESCRIPTION
This reverts commit dc604f0cdb3ed15b437b34a8d561be3f53cc4658.

Apparently it starts kicking everyone out after having 130+ online players (??)