### PR TITLE
Fix packet sending

### DIFF
--- a/sessions/packets.go
+++ b/sessions/packets.go
@@ -12,6 +12,12 @@ func SendPacketToConnection(data interface{}, conn net.Conn) {
 		return
 	}
 
+	user := GetUserByConnection(conn)
+	if user != nil {
+		user.ConnMutex.Lock()
+		defer user.ConnMutex.Unlock()
+	}
+
 	j, err := json.Marshal(data)
 
 	if err != nil {

--- a/sessions/user.go
+++ b/sessions/user.go
@@ -17,6 +17,8 @@ type User struct {
 	// The connection for the user
 	Conn net.Conn
 
+	ConnMutex *sync.Mutex
+
 	// The token used to identify the user for requests.
 	token string
 
@@ -64,6 +66,7 @@ type User struct {
 func NewUser(conn net.Conn, user *db.User) *User {
 	return &User{
 		Conn:              conn,
+		ConnMutex:         &sync.Mutex{},
 		token:             utils.GenerateRandomString(64),
 		Info:              user,
 		Mutex:             &sync.Mutex{},

--- a/utils/conn.go
+++ b/utils/conn.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"github.com/gobwas/ws"
 	"net"
 	"time"
 )
@@ -11,6 +12,14 @@ func CloseConnection(conn net.Conn) {
 		return
 	}
 
+	var body = ws.NewCloseFrameBody(1000, "")
+	var frame = ws.NewCloseFrame(body)
+	if err := ws.WriteHeader(conn, frame.Header); err != nil {
+		return
+	}
+	if _, err := conn.Write(body); err != nil {
+		return
+	}
 	_ = conn.Close()
 }
 


### PR DESCRIPTION
1. https://github.com/gobwas/ws/issues/133 and https://github.com/gobwas/ws/issues/176 suggests that connections are not thread safe, which could be the cause to the frame write racing issues we currently experience (this indirectly causes UTF-8 encoding errors, invalid header and opcode, and connections to be closed because the client complains about malformed packets).
2. Following https://github.com/gobwas/ws/issues/132 we now send a websocket close frame before closing the connection. This will solve the error emitted from the client, saying ConnectionClosedPrematurely, complaining that the server didn't finish the close handshake properly. Now the client will just say that the connection closed cleanly.