### PR TITLE
Fix sending packets to a closed channel (WaitGroup)

### DIFF
--- a/sessions/packets.go
+++ b/sessions/packets.go
@@ -48,6 +48,14 @@ func SendPacketToConnection(data interface{}, conn net.Conn) (err error) {
 
 // SendPacketToUser Sends a packet to a given user
 func SendPacketToUser(data interface{}, user *User) {
+	user.ChannelWaitGroup.Add(1)
+	defer user.ChannelWaitGroup.Done()
+
+	// Manage closing
+	if user.ChannelClosed {
+		return
+	}
+
 	user.PacketChannel.In <- data
 }
 

--- a/sessions/sessions.go
+++ b/sessions/sessions.go
@@ -52,8 +52,7 @@ func RemoveUser(user *User) error {
 	removeUserFromMaps(user)
 	user.StopSpectatingAll()
 
-	close(user.PacketChannel.In)
-	user.SessionClosed = true
+	user.ChannelShouldClose = true
 
 	err := UpdateRedisOnlineUserCount()
 


### PR DESCRIPTION
This is the implementation using a `sync.WaitGroup`. A goroutine is used to check if the channel should be closed. If it should be, then it will first set the Closed field, then wait for every sending function to end, and finally close the channel. Any sending function called after Closed field is set will not send because of the guard.