### PR TITLE
Add ability to disable preview

### DIFF
--- a/handlers/ClientGameEnablePreview.go
+++ b/handlers/ClientGameEnablePreview.go
@@ -1,0 +1,24 @@
+package handlers
+
+import (
+	"example.com/Quaver/Z/multiplayer"
+	"example.com/Quaver/Z/packets"
+	"example.com/Quaver/Z/sessions"
+)
+
+// Handles when the client wants to enable/disable preview for their multiplayer game
+func handleClientGameEnablePreview(user *sessions.User, packet *packets.ClientGameEnablePreview) {
+	if packet == nil {
+		return
+	}
+
+	game := multiplayer.GetGameById(user.GetMultiplayerGameId())
+
+	if game == nil {
+		return
+	}
+
+	game.RunLocked(func() {
+		game.SetEnablePreview(user, packet.Enabled)
+	})
+}

--- a/handlers/packets.go
+++ b/handlers/packets.go
@@ -116,6 +116,8 @@ func HandleIncomingPackets(conn net.Conn, msg string) {
 		handleClientGameAutoHost(user, unmarshalPacket[packets.ClientGameAutoHost](msg))
 	case packets.PacketIdClientLogout:
 		handleClientLogout(user, unmarshalPacket[packets.ClientLogout](msg))
+	case packets.PacketIdClientGameChangeEnablePreview:
+		handleClientGameEnablePreview(user, unmarshalPacket[packets.ClientGameEnablePreview](msg))
 	default:
 		log.Println(fmt.Errorf("unknown packet: %v", msg))
 	}

--- a/multiplayer/chat_bot.go
+++ b/multiplayer/chat_bot.go
@@ -79,6 +79,8 @@ func handleMultiplayerCommands(user *sessions.User, channel *chat.Channel, args 
 			message = handleCommandChangeMap(user, game, args)
 		case "hostrotation":
 			message = handleCommandHostRotation(user, game)
+		case "preview":
+			message = handleCommandEnablePreview(user, game)
 		case "maxplayers":
 			message = handleCommandMaxPlayers(user, game, args)
 		case "start":
@@ -239,6 +241,16 @@ func handleCommandHostRotation(user *sessions.User, game *Game) string {
 	}
 
 	game.SetHostRotation(user, !game.Data.IsHostRotation)
+	return ""
+}
+
+// Handles the command to enable/disable preview
+func handleCommandEnablePreview(user *sessions.User, game *Game) string {
+	if !game.isUserHost(user) {
+		return ""
+	}
+
+	game.SetEnablePreview(user, !game.Data.EnablePreview)
 	return ""
 }
 

--- a/multiplayer/game.go
+++ b/multiplayer/game.go
@@ -639,7 +639,7 @@ func (game *Game) SetHostRotation(requester *sessions.User, enabled bool) {
 	sendLobbyUsersGameInfoPacket(game, true)
 }
 
-// SetEnablePreview Sets whether host rotation will be enabled for the game
+// SetEnablePreview Sets whether previewing the map would be allowed for the game
 func (game *Game) SetEnablePreview(requester *sessions.User, enabled bool) {
 	if !game.isUserHost(requester) {
 		return

--- a/multiplayer/game.go
+++ b/multiplayer/game.go
@@ -639,6 +639,20 @@ func (game *Game) SetHostRotation(requester *sessions.User, enabled bool) {
 	sendLobbyUsersGameInfoPacket(game, true)
 }
 
+// SetEnablePreview Sets whether host rotation will be enabled for the game
+func (game *Game) SetEnablePreview(requester *sessions.User, enabled bool) {
+	if !game.isUserHost(requester) {
+		return
+	}
+
+	game.Data.EnablePreview = enabled
+	game.sendPacketToPlayers(packets.NewServerGameEnablePreview(game.Data.EnablePreview))
+	game.validateAndCacheSettings()
+
+	game.sendBotMessage(fmt.Sprintf("Preview has been %v.", utils.BoolToEnabledString(game.Data.EnablePreview)))
+	sendLobbyUsersGameInfoPacket(game, true)
+}
+
 // SetLongNotePercent Sets the minimum and maximum long note percentage filters for the game
 func (game *Game) SetLongNotePercent(requester *sessions.User, min int, max int) {
 	if !game.isUserHost(requester) {

--- a/multiplayer/redis.go
+++ b/multiplayer/redis.go
@@ -41,6 +41,7 @@ func (game *Game) cacheMatchSettings() {
 		"host", strconv.Itoa(game.Data.HostId),
 		"r", strconv.Itoa(int(game.Data.Ruleset)),
 		"hr", strconv.Itoa(utils.BoolToInt(game.Data.IsHostRotation)),
+		"ep", strconv.Itoa(utils.BoolToInt(game.Data.EnablePreview)),
 		"gm", strconv.Itoa(int(game.Data.MapGameMode)),
 		"d", strconv.FormatFloat(game.Data.MapDifficultyRating, 'f', -1, 64),
 		"inp", strconv.Itoa(utils.BoolToInt(game.Data.InProgress)),

--- a/objects/multiplayer_game.go
+++ b/objects/multiplayer_game.go
@@ -20,7 +20,7 @@ type MultiplayerGame struct {
 	MapDifficultyRatingAll    []float64                    `json:"adr"`           // The difficulty rating for all rates of the map. Host provides this for scoring on unsubmitted maps
 	Ruleset                   MultiplayerGameRuleset       `json:"r"`             // The rules of the match (free-for-all, team, etc)
 	IsHostRotation            bool                         `json:"hr"`            // Whether the server will control host rotation for the game
-	EnablePreview             bool                         `json:"ep"`            // Whether the server will control host rotation for the game
+	EnablePreview             bool                         `json:"ep"`            // Whether previewing the map is allowed for the game
 	InProgress                bool                         `json:"inp"`           // IF the match is currently in progress
 	HostId                    int                          `json:"h"`             // The id of the host
 	RefereeId                 int                          `json:"ref"`           // The id of the referee of the game

--- a/objects/multiplayer_game.go
+++ b/objects/multiplayer_game.go
@@ -20,6 +20,7 @@ type MultiplayerGame struct {
 	MapDifficultyRatingAll    []float64                    `json:"adr"`           // The difficulty rating for all rates of the map. Host provides this for scoring on unsubmitted maps
 	Ruleset                   MultiplayerGameRuleset       `json:"r"`             // The rules of the match (free-for-all, team, etc)
 	IsHostRotation            bool                         `json:"hr"`            // Whether the server will control host rotation for the game
+	EnablePreview             bool                         `json:"ep"`            // Whether the server will control host rotation for the game
 	InProgress                bool                         `json:"inp"`           // IF the match is currently in progress
 	HostId                    int                          `json:"h"`             // The id of the host
 	RefereeId                 int                          `json:"ref"`           // The id of the referee of the game
@@ -63,4 +64,5 @@ func (mg *MultiplayerGame) SetDefaults() {
 	mg.FilterMaxLongNotePercent = 100
 	mg.FilterMinAudioRate = 0.5
 	mg.IsTournamentMode = false
+	mg.EnablePreview = true
 }

--- a/packets/ClientGameEnablePreview.go
+++ b/packets/ClientGameEnablePreview.go
@@ -1,0 +1,6 @@
+package packets
+
+type ClientGameEnablePreview struct {
+	Packet
+	Enabled bool `json:"o"`
+}

--- a/packets/ServerGameEnablePreview.go
+++ b/packets/ServerGameEnablePreview.go
@@ -2,7 +2,7 @@ package packets
 
 type ServerGameEnablePreview struct {
 	Packet
-	Enabled bool `json:"h"`
+	Enabled bool `json:"e"`
 }
 
 func NewServerGameEnablePreview(enabled bool) *ServerGameEnablePreview {

--- a/packets/ServerGameEnablePreview.go
+++ b/packets/ServerGameEnablePreview.go
@@ -1,0 +1,13 @@
+package packets
+
+type ServerGameEnablePreview struct {
+	Packet
+	Enabled bool `json:"h"`
+}
+
+func NewServerGameEnablePreview(enabled bool) *ServerGameEnablePreview {
+	return &ServerGameEnablePreview{
+		Packet:  Packet{Id: PacketIdServerGameEnablePreviewChanged},
+		Enabled: enabled,
+	}
+}

--- a/packets/packet_id.go
+++ b/packets/packet_id.go
@@ -139,4 +139,6 @@ const (
 	PacketIdClientGameAutoHost
 	PacketIdServerGameAutoHost
 	PacketIdClientLogout
+	PacketIdClientGameChangeEnablePreview
+	PacketIdServerGameEnablePreviewChanged
 )


### PR DESCRIPTION
Requires https://github.com/Quaver/Quaver.Server.Client/pull/33

Adds EnablePreview toggle and relevant packet for multiplayer games. This does not have any effect on server side, but there is client code to prevent preview being enabled by the player if `EnablePreview == false`.

Adds a `!mp preview` command for toggling `EnablePreview`.