### PR TITLE
add mine hit stats to game judgements and score processing

### DIFF
--- a/handlers/ClientGameJudgements.go
+++ b/handlers/ClientGameJudgements.go
@@ -19,6 +19,6 @@ func handleClientGameJudgements(user *sessions.User, packet *packets.ClientGameJ
 	}
 
 	game.RunLocked(func() {
-		game.HandlePlayerJudgements(user.Info.Id, packet.Judgements)
+		game.HandlePlayerJudgements(user.Info.Id, packet.Judgements, packet.MineHitDelta)
 	})
 }

--- a/multiplayer/game.go
+++ b/multiplayer/game.go
@@ -786,17 +786,17 @@ func (game *Game) SetPlayerSkippedSong(userId int) {
 }
 
 // HandlePlayerJudgements Handles when a player sends judgement data during a multiplayer match
-func (game *Game) HandlePlayerJudgements(userId int, judgements []common.Judgements) {
+func (game *Game) HandlePlayerJudgements(userId int, judgements []common.Judgements, mineHitDelta int) {
 	if !game.Data.InProgress || !utils.Includes(game.playersInMatch, userId) {
 		return
 	}
 
 	if score, ok := game.playerScores[userId]; ok {
-		score.AddJudgements(judgements)
+		score.AddJudgements(judgements, mineHitDelta)
 		game.cachePlayerScore(userId, score)
 	}
 
-	packet := packets.NewServerGameJudgements(userId, judgements)
+	packet := packets.NewServerGameJudgements(userId, judgements, mineHitDelta)
 
 	for _, playerId := range game.playersInMatch {
 		if playerId == userId {
@@ -1085,6 +1085,7 @@ func (game *Game) insertMatchIntoDatabase() {
 			CountGood:         score.Judgements[common.JudgementGood],
 			CountOkay:         score.Judgements[common.JudgementOkay],
 			CountMiss:         score.Judgements[common.JudgementMiss],
+			CountMineHit:      score.CountMineHit,
 			Won:               int(winResult),
 		}
 

--- a/packets/ClientGameJudgements.go
+++ b/packets/ClientGameJudgements.go
@@ -4,5 +4,6 @@ import "example.com/Quaver/Z/common"
 
 type ClientGameJudgements struct {
 	Packet
-	Judgements []common.Judgements `json:"j"`
+	Judgements   []common.Judgements `json:"j"`
+	MineHitDelta int                 `json:"m"`
 }

--- a/packets/ServerGameJudgements.go
+++ b/packets/ServerGameJudgements.go
@@ -4,14 +4,16 @@ import "example.com/Quaver/Z/common"
 
 type ServerGameJudgements struct {
 	Packet
-	UserId     int                 `json:"u"`
-	Judgements []common.Judgements `json:"j"`
+	UserId       int                 `json:"u"`
+	Judgements   []common.Judgements `json:"j"`
+	MineHitDelta int                 `json:"m"`
 }
 
-func NewServerGameJudgements(userId int, judgements []common.Judgements) *ServerGameJudgements {
+func NewServerGameJudgements(userId int, judgements []common.Judgements, mineHitDelta int) *ServerGameJudgements {
 	return &ServerGameJudgements{
-		Packet:     Packet{Id: PacketIdServerGameJudgements},
-		UserId:     userId,
-		Judgements: judgements,
+		Packet:       Packet{Id: PacketIdServerGameJudgements},
+		UserId:       userId,
+		Judgements:   judgements,
+		MineHitDelta: mineHitDelta,
 	}
 }

--- a/scoring/score_processor.go
+++ b/scoring/score_processor.go
@@ -13,6 +13,7 @@ type ScoreProcessor struct {
 	Combo             int
 	MaxCombo          int
 	Judgements        map[common.Judgements]int
+	CountMineHit      int
 }
 
 func NewScoreProcessor(difficultyRating float64, modifiers common.Mods) *ScoreProcessor {
@@ -24,10 +25,11 @@ func NewScoreProcessor(difficultyRating float64, modifiers common.Mods) *ScorePr
 }
 
 // AddJudgements Adds new judgements to the score
-func (sp *ScoreProcessor) AddJudgements(judgements []common.Judgements) {
+func (sp *ScoreProcessor) AddJudgements(judgements []common.Judgements, mineHitDelta int) {
 	for _, j := range judgements {
 		sp.addJudgement(j)
 	}
+	sp.addMineHits(mineHitDelta)
 
 	sp.calculateAccuracy()
 	sp.calculatePerformanceRating()
@@ -46,6 +48,11 @@ func (sp *ScoreProcessor) addJudgement(judgement common.Judgements) {
 	} else {
 		sp.Combo = 0
 	}
+}
+
+// addMineHits Adds a number of new mine hits to the score
+func (sp *ScoreProcessor) addMineHits(count int) {
+	sp.CountMineHit += count
 }
 
 // Calculates the accuracy of the current score


### PR DESCRIPTION
This adds a MineHitDelta field which is the number increment to the count of mine hits for this packet. This would add the number to the current mine hit count to a player.